### PR TITLE
📝Fix jitpack instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ repositories {
 }
 
 dependencies {
-    implementation "com.github.Ocelot5836:molang-compiler:version"
-    shade "com.github.Ocelot5836:molang-compiler:version"
+    implementation "com.github.molang-compiler:molang-compiler:version"
+    shade "com.github.MoonflowerTeam:molang-compiler:version"
 }
 
 shadowJar {


### PR DESCRIPTION
Since the project was moved to the MoonflowerTeam repository, the jitpack instructions are incorrect. This should fix that.